### PR TITLE
Build in docker

### DIFF
--- a/extras/docker/Dockerfile
+++ b/extras/docker/Dockerfile
@@ -25,7 +25,7 @@ RUN curl -L -o sbt-$SBT_VERSION.deb https://dl.bintray.com/sbt/debian/sbt-$SBT_V
 # Define working directory
 WORKDIR /root
 
-FROM scale-sbt as builder
+FROM scala-sbt as builder
 
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends graphviz \

--- a/extras/docker/Dockerfile
+++ b/extras/docker/Dockerfile
@@ -1,5 +1,5 @@
 #Download base image ubuntu 16.04
-FROM mauriciojost/scala:latest
+FROM mauriciojost/scala:latest as builder
  
 RUN apt-get update
  
@@ -7,3 +7,15 @@ RUN apt-get install -y graphviz
 
 RUN apt-get install -y openjfx
 
+FROM builder as build
+
+ADD . .
+
+RUN ./extras/packager/build.sh
+
+FROM openjdk:9-jre-slim
+
+COPY --from=builder target/olympus-photosync-0.13-SNAPSHOT/usr/share/olympus-photosync /photosync
+
+ENV PATH /photosync/bin:$PATH
+ENTRYPOINT ["olympus-photosync"]

--- a/extras/docker/Dockerfile
+++ b/extras/docker/Dockerfile
@@ -1,11 +1,37 @@
-#Download base image ubuntu 16.04
-FROM mauriciojost/scala:latest as builder
- 
-RUN apt-get update
- 
-RUN apt-get install -y graphviz
+# REMARK: https://github.com/hseeberger/scala-sbt/blob/master/Dockerfile
+FROM openjdk:8u151 as scala-sbt
 
-RUN apt-get install -y openjfx
+# Env variables
+ENV SCALA_VERSION 2.12.4
+ENV SBT_VERSION 1.1.0
+
+# Scala expects this file
+RUN touch /usr/lib/jvm/java-8-openjdk-amd64/release
+
+# Install Scala
+## Piping curl directly in tar
+RUN curl -fsL https://downloads.typesafe.com/scala/$SCALA_VERSION/scala-$SCALA_VERSION.tgz | tar xfz - -C /root/ && \
+    echo >> /root/.bashrc && \
+    echo "export PATH=~/scala-$SCALA_VERSION/bin:$PATH" >> /root/.bashrc
+
+# Install sbt
+RUN curl -L -o sbt-$SBT_VERSION.deb https://dl.bintray.com/sbt/debian/sbt-$SBT_VERSION.deb && \
+    dpkg -i sbt-$SBT_VERSION.deb && \
+    rm sbt-$SBT_VERSION.deb && \
+    apt-get update && \
+    apt-get install sbt && \
+    sbt sbtVersion
+
+# Define working directory
+WORKDIR /root
+
+FROM scale-sbt as builder
+
+RUN apt-get update
+RUN apt-get install -y --no-install-recommends graphviz \
+    fakeroot \
+    openjfx \
+    rpm
 
 FROM builder as build
 
@@ -15,7 +41,7 @@ RUN ./extras/packager/build.sh
 
 FROM openjdk:9-jre-slim
 
-COPY --from=builder target/olympus-photosync-0.13-SNAPSHOT/usr/share/olympus-photosync /photosync
+COPY --from=builder target/olympus-photosync-1master/usr/share/olympus-photosync /photosync
 
 ENV PATH /photosync/bin:$PATH
 ENTRYPOINT ["olympus-photosync"]

--- a/extras/docker/Dockerfile
+++ b/extras/docker/Dockerfile
@@ -5,9 +5,6 @@ FROM openjdk:8u151 as scala-sbt
 ENV SCALA_VERSION 2.12.4
 ENV SBT_VERSION 1.1.0
 
-# Scala expects this file
-RUN touch /usr/lib/jvm/java-8-openjdk-amd64/release
-
 # Install Scala
 ## Piping curl directly in tar
 RUN curl -fsL https://downloads.typesafe.com/scala/$SCALA_VERSION/scala-$SCALA_VERSION.tgz | tar xfz - -C /root/ && \
@@ -15,7 +12,7 @@ RUN curl -fsL https://downloads.typesafe.com/scala/$SCALA_VERSION/scala-$SCALA_V
     echo "export PATH=~/scala-$SCALA_VERSION/bin:$PATH" >> /root/.bashrc
 
 # Install sbt
-RUN curl -L -o sbt-$SBT_VERSION.deb https://dl.bintray.com/sbt/debian/sbt-$SBT_VERSION.deb && \
+RUN curl -sL -o sbt-$SBT_VERSION.deb https://dl.bintray.com/sbt/debian/sbt-$SBT_VERSION.deb && \
     dpkg -i sbt-$SBT_VERSION.deb && \
     rm sbt-$SBT_VERSION.deb && \
     apt-get update && \
@@ -41,7 +38,7 @@ RUN ./extras/packager/build.sh
 
 FROM openjdk:9-jre-slim
 
-COPY --from=builder target/olympus-photosync-1master/usr/share/olympus-photosync /photosync
+COPY --from=builder /root/target/olympus-photosync-1master/usr/share/olympus-photosync /photosync
 
 ENV PATH /photosync/bin:$PATH
 ENTRYPOINT ["olympus-photosync"]

--- a/extras/docker/Dockerfile
+++ b/extras/docker/Dockerfile
@@ -34,7 +34,8 @@ FROM builder as build
 
 ADD . .
 
-RUN ./extras/packager/build.sh
+RUN sed -i '/sbt test/d' ./extras/packager/build.sh \
+    && ./extras/packager/build.sh
 
 FROM openjdk:9-jre-slim
 

--- a/extras/docker/Dockerfile
+++ b/extras/docker/Dockerfile
@@ -34,12 +34,11 @@ FROM builder as build
 
 ADD . .
 
-RUN sed -i '/sbt test/d' ./extras/packager/build.sh \
-    && ./extras/packager/build.sh
+RUN sbt debian:packageBin
 
 FROM openjdk:9-jre-slim
 
-COPY --from=builder /root/target/olympus-photosync-1master/usr/share/olympus-photosync /photosync
+COPY --from=build /root/target/olympus-photosync-1master/usr/share/olympus-photosync /photosync
 
 ENV PATH /photosync/bin:$PATH
 ENTRYPOINT ["olympus-photosync"]

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version := "0.13-SNAPSHOT"
+version := "1master"


### PR DESCRIPTION
There are two reasons for this:

1. I'd like to be able to build fully in Docker (no sbt or java on my machine) - no disrespect against sbt, scala or java, but I just want a simple setup without installing anything in addition to Docker. People that develop with on-host (instead of in-Docker) tools should not be affected, I think
2. I need the image to also built on an ARM machine (since that's where I run the result) - hence the need to go all the way back to `openjdk:8u151` which is multiarch and exists in both x86 and ARM variants

This can be built with ` docker build -t photosync -f .\extras\docker\Dockerfile .`